### PR TITLE
Add jQuery validation localization file

### DIFF
--- a/vendor/assets/javascripts/jquery.validate.localization.js
+++ b/vendor/assets/javascripts/jquery.validate.localization.js
@@ -1,0 +1,1 @@
+//= require_tree jquery.validate.localization


### PR DESCRIPTION
Added a `jquery.validate.localization.js` file to require all localization files since `require_tree jquery.validate.localization` on an app seems to raise this as an error `require_tree argument must be a relative path`. Requiring now the jquery.validate.localization would be `require jquery.validate.localization` instead of `require_tree jquery.validate.localization`.